### PR TITLE
Updated batch processing

### DIFF
--- a/server/Infrastructure/Infrastructure.Cosmos/CosmosRepository.cs
+++ b/server/Infrastructure/Infrastructure.Cosmos/CosmosRepository.cs
@@ -1,5 +1,4 @@
 using System.Linq.Expressions;
-using Ardalis.GuardClauses;
 using Domain.Abstractions;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Linq;
@@ -13,9 +12,7 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
 {
     private readonly ICosmosProvider _cosmosProvider;
     private readonly ILogger<CosmosRepository<TEntity>> _logger;
-
-    public CosmosRepository(
-        ICosmosProvider cosmosProvider,
+    public CosmosRepository(ICosmosProvider cosmosProvider,
         ILogger<CosmosRepository<TEntity>> logger)
     {
         _cosmosProvider = cosmosProvider;
@@ -25,7 +22,7 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public async Task<TEntity?> FindAsync(string id, string partitionKeyValue,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { id, partitionKeyValue });
+        _logger.LogMethodCall(new {id, partitionKeyValue});
 
         var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
         ItemResponse<TEntity>? result;
@@ -38,7 +35,7 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         }
         catch (CosmosException cex)
         {
-            _logger.LogCosmosException(new { id, partitionKeyValue }, cex);
+            _logger.LogCosmosException(new {id, partitionKeyValue}, cex);
             throw new CosmosFriendlyException("Query failed. See inner exception for details.", cex);
         }
 
@@ -54,21 +51,21 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public Task<IPagedData<TEntity>> QueryAsync(Expression<Func<TEntity, dynamic>> orderBySelector,
         string orderByDirection = "ASC", CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { orderBySelector, orderByDirection });
+        _logger.LogMethodCall(new {orderBySelector, orderByDirection});
         return QueryInternalAsync(null, null, null, 0, orderBySelector, orderByDirection,
             cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> QueryAsync(int maxItems, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { maxItems });
+        _logger.LogMethodCall(new {maxItems});
         return QueryInternalAsync(null, null, null, maxItems, cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> QueryAsync(int maxItems, Expression<Func<TEntity, dynamic>> orderBySelector,
         string orderByDirection = "ASC", CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { maxItems, orderBySelector, orderByDirection });
+        _logger.LogMethodCall(new {maxItems, orderBySelector, orderByDirection});
         return QueryInternalAsync(null, null, null, maxItems, orderBySelector, orderByDirection,
             cancellationToken: cancellationToken);
     }
@@ -76,7 +73,7 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public Task<IPagedData<TEntity>> QueryAsync(Expression<Func<TEntity, bool>>? whereExpression,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression });
+        _logger.LogMethodCall(new {whereExpression});
         return QueryInternalAsync(whereExpression, null, null, 0, cancellationToken: cancellationToken);
     }
 
@@ -84,14 +81,15 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         Expression<Func<TEntity, dynamic>> orderBySelector,
         string orderByDirection = "ASC", CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, orderBySelector, orderByDirection });
-        return QueryInternalAsync(whereExpression, null, null, 0, orderBySelector, orderByDirection, cancellationToken: cancellationToken);
+        _logger.LogMethodCall(new {whereExpression, orderBySelector, orderByDirection});
+        return QueryInternalAsync(whereExpression, null, null, 0, orderBySelector, orderByDirection,
+            cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> QueryAsync(Expression<Func<TEntity, bool>>? whereExpression, int maxItems,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, maxItems });
+        _logger.LogMethodCall(new {whereExpression, maxItems});
         return QueryInternalAsync(whereExpression, null, null, maxItems, cancellationToken: cancellationToken);
     }
 
@@ -99,27 +97,30 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         Expression<Func<TEntity, dynamic>> orderBySelector,
         string orderByDirection = "ASC", CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, maxItems, orderBySelector, orderByDirection });
-        return QueryInternalAsync(whereExpression, null, null, maxItems, orderBySelector, orderByDirection, cancellationToken: cancellationToken);
+        _logger.LogMethodCall(new {whereExpression, maxItems, orderBySelector, orderByDirection});
+        return QueryInternalAsync(whereExpression, null, null, maxItems, orderBySelector, orderByDirection,
+            cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> QueryAsync(string partitionKeyValue, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { partitionKeyValue });
+        _logger.LogMethodCall(new {partitionKeyValue});
         return QueryInternalAsync(null, partitionKeyValue, null, 0, cancellationToken: cancellationToken);
     }
 
-    public Task<IPagedData<TEntity>> QueryAsync(string partitionKeyValue, Expression<Func<TEntity, dynamic>> orderBySelector,
+    public Task<IPagedData<TEntity>> QueryAsync(string partitionKeyValue,
+        Expression<Func<TEntity, dynamic>> orderBySelector,
         string orderByDirection = "ASC", CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { partitionKeyValue, orderBySelector, orderByDirection });
-        return QueryInternalAsync(null, partitionKeyValue, null, 0, orderBySelector, orderByDirection, cancellationToken: cancellationToken);
+        _logger.LogMethodCall(new {partitionKeyValue, orderBySelector, orderByDirection});
+        return QueryInternalAsync(null, partitionKeyValue, null, 0, orderBySelector, orderByDirection,
+            cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> QueryAsync(string partitionKeyValue, int maxItems,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { partitionKeyValue, maxItems });
+        _logger.LogMethodCall(new {partitionKeyValue, maxItems});
         return QueryInternalAsync(null, partitionKeyValue, null, maxItems, cancellationToken: cancellationToken);
     }
 
@@ -127,21 +128,22 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         Expression<Func<TEntity, dynamic>> orderBySelector,
         string orderByDirection = "ASC", CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { partitionKeyValue, maxItems, orderBySelector, orderByDirection });
-        return QueryInternalAsync(null, partitionKeyValue, null, maxItems, orderBySelector, orderByDirection, cancellationToken: cancellationToken);
+        _logger.LogMethodCall(new {partitionKeyValue, maxItems, orderBySelector, orderByDirection});
+        return QueryInternalAsync(null, partitionKeyValue, null, maxItems, orderBySelector, orderByDirection,
+            cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> QueryAsync(Expression<Func<TEntity, bool>>? whereExpression,
         string partitionKeyValue, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, partitionKeyValue });
+        _logger.LogMethodCall(new {whereExpression, partitionKeyValue});
         return QueryInternalAsync(whereExpression, partitionKeyValue, null, 0, cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> QueryAsync(Expression<Func<TEntity, bool>>? whereExpression,
         string partitionKeyValue, int maxItems, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, partitionKeyValue, maxItems });
+        _logger.LogMethodCall(new {whereExpression, partitionKeyValue, maxItems});
         return QueryInternalAsync(whereExpression, partitionKeyValue, null, maxItems,
             cancellationToken: cancellationToken);
     }
@@ -149,14 +151,14 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public Task<IPagedData<TEntity>> ContinueQueryAsync(string partitionKeyValue, string continuationToken,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { partitionKeyValue, continuationToken });
+        _logger.LogMethodCall(new {partitionKeyValue, continuationToken});
         return QueryInternalAsync(null, partitionKeyValue, continuationToken, 0, cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> ContinueQueryAsync(string partitionKeyValue, int maxItems,
         string continuationToken, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { partitionKeyValue, maxItems, continuationToken });
+        _logger.LogMethodCall(new {partitionKeyValue, maxItems, continuationToken});
         return QueryInternalAsync(null, partitionKeyValue, continuationToken, maxItems,
             cancellationToken: cancellationToken);
     }
@@ -164,14 +166,14 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public Task<IPagedData<TEntity>> ContinueQueryAsync(int maxItems, string continuationToken,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { maxItems, continuationToken });
+        _logger.LogMethodCall(new {maxItems, continuationToken});
         return QueryInternalAsync(null, null, continuationToken, maxItems, cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> ContinueQueryAsync(Expression<Func<TEntity, bool>>? whereExpression, int maxItems,
         string continuationToken, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, maxItems, continuationToken });
+        _logger.LogMethodCall(new {whereExpression, maxItems, continuationToken});
         return QueryInternalAsync(whereExpression, null, continuationToken, maxItems,
             cancellationToken: cancellationToken);
     }
@@ -179,21 +181,21 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public Task<IPagedData<TEntity>> ContinueQueryAsync(string continuationToken,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { continuationToken });
+        _logger.LogMethodCall(new {continuationToken});
         return QueryInternalAsync(null, null, continuationToken, 0, cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> ContinueQueryAsync(Expression<Func<TEntity, bool>>? whereExpression,
         string continuationToken, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, continuationToken });
+        _logger.LogMethodCall(new {whereExpression, continuationToken});
         return QueryInternalAsync(whereExpression, null, continuationToken, 0, cancellationToken: cancellationToken);
     }
 
     public Task<IPagedData<TEntity>> ContinueQueryAsync(Expression<Func<TEntity, bool>>? whereExpression,
         string partitionKeyValue, int maxItems, string continuationToken, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, partitionKeyValue, maxItems, continuationToken });
+        _logger.LogMethodCall(new {whereExpression, partitionKeyValue, maxItems, continuationToken});
         return QueryInternalAsync(whereExpression, partitionKeyValue, continuationToken, maxItems,
             cancellationToken: cancellationToken);
     }
@@ -201,7 +203,7 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public Task<IPagedData<TEntity>> ContinueQueryAsync(Expression<Func<TEntity, bool>>? whereExpression,
         string partitionKeyValue, string continuationToken, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, partitionKeyValue, continuationToken });
+        _logger.LogMethodCall(new {whereExpression, partitionKeyValue, continuationToken});
         return QueryInternalAsync(whereExpression, partitionKeyValue, continuationToken, 0,
             cancellationToken: cancellationToken);
     }
@@ -215,7 +217,7 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         string orderByDirection = "ASC",
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, partitionKeyValue, continuationToken, maxItems });
+        _logger.LogMethodCall(new {whereExpression, partitionKeyValue, continuationToken, maxItems});
         var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
 
         var options = new QueryRequestOptions();
@@ -255,7 +257,7 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         }
         catch (CosmosException cex)
         {
-            _logger.LogCosmosException(new { whereExpression, partitionKeyValue, continuationToken, maxItems }, cex);
+            _logger.LogCosmosException(new {whereExpression, partitionKeyValue, continuationToken, maxItems}, cex);
             throw new CosmosFriendlyException("Query failed. See inner exception for details.", cex);
         }
     }
@@ -263,33 +265,33 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public Task<int> CountAsync(Expression<Func<TEntity, bool>>? whereExpression,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression });
+        _logger.LogMethodCall(new {whereExpression});
         return CountInternalAsync(whereExpression, null, cancellationToken);
     }
 
     public Task<int> CountAsync(string partitionKeyValue, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { partitionKeyValue });
+        _logger.LogMethodCall(new {partitionKeyValue});
         return CountInternalAsync(null, partitionKeyValue, cancellationToken);
     }
 
     public Task<int> CountAsync(Expression<Func<TEntity, bool>>? whereExpression, string partitionKeyValue,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, partitionKeyValue });
+        _logger.LogMethodCall(new {whereExpression, partitionKeyValue});
         return CountInternalAsync(whereExpression, partitionKeyValue, cancellationToken);
     }
 
     private async Task<int> CountInternalAsync(Expression<Func<TEntity, bool>>? whereExpression,
         string? partitionKeyValue, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, partitionKeyValue });
+        _logger.LogMethodCall(new {whereExpression, partitionKeyValue});
         var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
 
         QueryRequestOptions? options = null;
 
         if (!string.IsNullOrWhiteSpace(partitionKeyValue))
-            options = new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKeyValue), };
+            options = new QueryRequestOptions {PartitionKey = new PartitionKey(partitionKeyValue),};
 
         try
         {
@@ -306,7 +308,7 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         }
         catch (CosmosException cex)
         {
-            _logger.LogCosmosException(new { whereExpression, partitionKeyValue }, cex);
+            _logger.LogCosmosException(new {whereExpression, partitionKeyValue}, cex);
             throw new CosmosFriendlyException(
                 "An error occurred while attempting to process a 'count' query in Cosmos. See the inner exception for more details.",
                 cex);
@@ -316,25 +318,25 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public async Task<bool> ExistsAsync(string id, string partitionKeyValue,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { id, partitionKeyValue });
-        Guard.Against.NullOrWhiteSpace(id);
-        Guard.Against.NullOrWhiteSpace(partitionKeyValue);
+        _logger.LogMethodCall(new {id, partitionKeyValue});
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(partitionKeyValue);
         return await CountInternalAsync(x => x.Id == id, partitionKeyValue, cancellationToken).ConfigureAwait(false) >
                0;
     }
 
     public async Task<bool> ExistsAsync(string id, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { id });
-        Guard.Against.NullOrWhiteSpace(id);
+        _logger.LogMethodCall(new {id});
+        ArgumentNullException.ThrowIfNull(id);
         return await CountInternalAsync(x => x.Id == id, null, cancellationToken).ConfigureAwait(false) > 0;
     }
 
     public async Task<bool> ExistsAsync(Expression<Func<TEntity, bool>>? whereExpression, string partitionKeyValue,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression, partitionKeyValue });
-        Guard.Against.NullOrWhiteSpace(partitionKeyValue);
+        _logger.LogMethodCall(new {whereExpression, partitionKeyValue});
+        ArgumentNullException.ThrowIfNull(partitionKeyValue);
         return await CountInternalAsync(whereExpression, partitionKeyValue, cancellationToken).ConfigureAwait(false) >
                0;
     }
@@ -342,16 +344,19 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public async Task<bool> ExistsAsync(Expression<Func<TEntity, bool>>? whereExpression,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { whereExpression });
+        _logger.LogMethodCall(new {whereExpression});
         return await CountInternalAsync(whereExpression, null, cancellationToken).ConfigureAwait(false) > 0;
     }
 
     public async Task<TEntity?> CreateAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { entity });
-        Guard.Against.Null(entity);
-        Guard.Against.NullOrWhiteSpace(entity.Id);
-        Guard.Against.NullOrWhiteSpace(entity.PartitionKey);
+        _logger.LogMethodCall(new {entity});
+        ArgumentNullException.ThrowIfNull(entity);
+        if (string.IsNullOrEmpty(entity.Id))
+            throw new ArgumentNullException(nameof(entity), "Entity ID is not set");
+
+        if (entity.PartitionKey is null)
+            throw new ArgumentNullException(nameof(entity), "Entity PartitionKey is null");
 
         var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
 
@@ -366,49 +371,20 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         }
         catch (CosmosException cex)
         {
-            _logger.LogCosmosException(new { entity }, cex);
+            _logger.LogCosmosException(new {entity}, cex);
             return null;
-        }
-    }
-
-    public async Task CreateAsBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
-    {
-        var enumeratedEntities = entities.ToList();
-        _logger.LogMethodCall(new { enumeratedEntities });
-        Guard.Against.NullOrEmpty(enumeratedEntities, nameof(entities));
-
-        if (enumeratedEntities.Select(x => x.PartitionKey).Distinct(StringComparer.Ordinal).Skip(1).Any())
-            throw new CosmosFriendlyException(
-                "Cannot create as batch unless all items in the batch have the same partition key value");
-
-        var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
-
-        try
-        {
-            var transaction =
-                container.CreateTransactionalBatch(new PartitionKey(enumeratedEntities[0].PartitionKey));
-
-            foreach (var entity in enumeratedEntities)
-            {
-                transaction.CreateItem(entity);
-            }
-
-            using var result = await transaction.ExecuteAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogCosmosDiagnosticsTrace("Batch create", result.RequestCharge, result.Diagnostics);
-        }
-        catch (CosmosException cex)
-        {
-            _logger.LogCosmosException(new { enumeratedEntities }, cex);
-            throw new CosmosFriendlyException("Batch create failed. See inner exception for details.", cex);
         }
     }
 
     public async Task<TEntity?> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { entity });
-        Guard.Against.Null(entity);
-        Guard.Against.NullOrWhiteSpace(entity.Id);
-        Guard.Against.NullOrWhiteSpace(entity.PartitionKey);
+        _logger.LogMethodCall(new {entity});
+        ArgumentNullException.ThrowIfNull(entity);
+        if (string.IsNullOrEmpty(entity.Id))
+            throw new ArgumentNullException(nameof(entity), "Entity ID is not set");
+
+        if (entity.PartitionKey is null)
+            throw new ArgumentNullException(nameof(entity), "Entity PartitionKey is null");
 
         var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
 
@@ -424,7 +400,7 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         }
         catch (CosmosException cex)
         {
-            _logger.LogCosmosException(new { entity }, cex);
+            _logger.LogCosmosException(new {entity}, cex);
             return null;
         }
     }
@@ -432,10 +408,10 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
     public async Task<TEntity?> PatchAsync(JsonPatch patch, string id, string partitionKeyValue,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { patch, id, partitionKeyValue });
-        Guard.Against.Null(patch);
-        Guard.Against.NullOrWhiteSpace(id);
-        Guard.Against.NullOrWhiteSpace(partitionKeyValue);
+        _logger.LogMethodCall(new {patch, id, partitionKeyValue});
+        ArgumentNullException.ThrowIfNull(patch);
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(partitionKeyValue);
 
         var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
 
@@ -449,31 +425,32 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         }
         catch (CosmosException cex)
         {
-            _logger.LogCosmosException(new { patch, id, partitionKeyValue }, cex);
+            _logger.LogCosmosException(new {patch, id, partitionKeyValue}, cex);
             throw;
         }
     }
 
     public Task<bool> DeleteAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { entity });
-        Guard.Against.Null(entity);
+        _logger.LogMethodCall(new {entity});
+        ArgumentNullException.ThrowIfNull(entity);
         return DeleteAsync(entity.Id, entity.PartitionKey, cancellationToken);
     }
 
     public async Task<bool> DeleteAsync(string id, string partitionKeyValue,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogMethodCall(new { id, partitionKeyValue });
-        Guard.Against.NullOrWhiteSpace(id);
-        Guard.Against.NullOrWhiteSpace(partitionKeyValue);
+        _logger.LogMethodCall(new {id, partitionKeyValue});
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(partitionKeyValue);
 
         var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
             var result = await container
-                .DeleteItemAsync<TEntity>(id, new PartitionKey(partitionKeyValue), cancellationToken: cancellationToken)
+                .DeleteItemAsync<TEntity>(id, new PartitionKey(partitionKeyValue),
+                    cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             _logger.LogCosmosDiagnosticsTrace("Delete item", result.RequestCharge, result.Diagnostics);
 
@@ -481,58 +458,147 @@ public sealed class CosmosRepository<TEntity> : IRepository<TEntity>
         }
         catch (CosmosException cex)
         {
-            _logger.LogCosmosException(new { id, partitionKeyValue }, cex);
+            _logger.LogCosmosException(new {id, partitionKeyValue}, cex);
             return false;
         }
     }
 
-    public Task DeleteAsBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+    public async Task CreateAsBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
     {
-        var enumeratedEntities = entities.ToList();
-        _logger.LogMethodCall(new { enumerateEntities = enumeratedEntities });
-        Guard.Against.NullOrEmpty(enumeratedEntities, nameof(entities));
-
-        var distinctPartitionKeys =
-            enumeratedEntities.Select(x => x.PartitionKey).Distinct(StringComparer.Ordinal).ToList();
-
-        if (!distinctPartitionKeys.Any())
-            throw new CosmosFriendlyException(
-                "Cannot delete items that have no partition key");
-
-        if (distinctPartitionKeys.Skip(1).Any())
-            throw new CosmosFriendlyException(
-                "Cannot create as batch unless all items in the batch have the same partition key value");
-
-        return DeleteAsBatchAsync(enumeratedEntities.Select(x => x.Id), distinctPartitionKeys[0], cancellationToken);
-    }
-
-    public async Task DeleteAsBatchAsync(IEnumerable<string> ids, string partitionKeyValue,
-        CancellationToken cancellationToken = default)
-    {
-        var enumeratedIds = ids.ToList();
-        _logger.LogMethodCall(new { enumeratedIds, partitionKeyValue });
-        Guard.Against.NullOrEmpty(enumeratedIds, nameof(ids));
-        Guard.Against.NullOrWhiteSpace(partitionKeyValue);
+        var enumeratedEntities = entities as TEntity[] ?? entities.ToArray();
+        if (enumeratedEntities.Length == 0)
+        {
+            return; // no point in throwing anything here - just act like we're done
+        }
 
         var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
 
-        try
-        {
-            var transaction =
-                container.CreateTransactionalBatch(new PartitionKey(partitionKeyValue));
+        var partitionedEntities = enumeratedEntities.GroupBy(e => e.PartitionKey, StringComparer.Ordinal);
 
-            foreach (var id in enumeratedIds)
+        foreach (var groupedEntity in partitionedEntities)
+        {
+            var batches = BuildBatches(groupedEntity.ToArray());
+
+            foreach (var batch in batches)
             {
-                transaction.DeleteItem(id);
+                var transaction = container.CreateTransactionalBatch(new PartitionKey(groupedEntity.Key));
+
+                foreach (var entity in batch)
+                {
+                    transaction.CreateItem(entity);
+                }
+
+                try
+                {
+                    var response = await transaction.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+                    _logger.LogCosmosDiagnosticsTrace(nameof(CreateAsBatchAsync), response.RequestCharge,
+                        response.Diagnostics);
+                }
+                catch (CosmosException cex)
+                {
+                    _logger.LogCosmosException(new {enumeratedEntities}, cex);
+                    throw;
+                }
+            }
+        }
+    }
+
+    public async Task UpdateAsBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+    {
+        var enumeratedEntities = entities as TEntity[] ?? entities.ToArray();
+        if (enumeratedEntities.Length == 0)
+        {
+            return;
+        }
+
+        var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
+
+        var partitionedEntities = enumeratedEntities.GroupBy(e => e.PartitionKey, StringComparer.Ordinal);
+
+        foreach (var groupedEntity in partitionedEntities)
+        {
+            var batches = BuildBatches(groupedEntity.ToArray());
+
+            foreach (var batch in batches)
+            {
+                var transaction = container.CreateTransactionalBatch(new PartitionKey(groupedEntity.Key));
+
+                foreach (var entity in batch)
+                {
+                    transaction.ReplaceItem(entity.Id, entity);
+                }
+
+                try
+                {
+                    var response = await transaction.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+                    _logger.LogCosmosDiagnosticsTrace(nameof(UpdateAsBatchAsync), response.RequestCharge,
+                        response.Diagnostics);
+                }
+                catch (CosmosException cex)
+                {
+                    _logger.LogCosmosException(new {enumeratedEntities}, cex);
+                    throw;
+                }
+            }
+        }
+    }
+
+    public async Task DeleteAsBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+    {
+        var enumeratedEntities = entities as TEntity[] ?? entities.ToArray();
+        if (enumeratedEntities.Length == 0)
+        {
+            return;
+        }
+
+        var container = await _cosmosProvider.GetContainerAsync(cancellationToken).ConfigureAwait(false);
+
+        var partitionedEntities = enumeratedEntities.GroupBy(e => e.PartitionKey, StringComparer.Ordinal);
+
+        foreach (var groupedEntity in partitionedEntities)
+        {
+            var batches = BuildBatches(groupedEntity.ToArray());
+
+            foreach (var batch in batches)
+            {
+                var transaction = container.CreateTransactionalBatch(new PartitionKey(groupedEntity.Key));
+
+                foreach (var entity in batch)
+                {
+                    transaction.DeleteItem(entity.Id);
+                }
+
+                try
+                {
+                    var response = await transaction.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+                    _logger.LogCosmosDiagnosticsTrace(nameof(DeleteAsBatchAsync), response.RequestCharge,
+                        response.Diagnostics);
+                }
+                catch (CosmosException cex)
+                {
+                    _logger.LogCosmosException(new {enumeratedEntities}, cex);
+                    throw;
+                }
+            }
+        }
+    }
+
+    private static List<List<TEntity>> BuildBatches(IReadOnlyList<TEntity> enumeratedEntities)
+    {
+        const int batchSize = 100;
+        var batches = new List<List<TEntity>>();
+        for (var i = 0; i < enumeratedEntities.Count; i += batchSize)
+        {
+            var batch = new List<TEntity>();
+
+            for (var j = i; j < i + batchSize && j < enumeratedEntities.Count; j++)
+            {
+                batch.Add(enumeratedEntities[j]);
             }
 
-            using var result = await transaction.ExecuteAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogCosmosDiagnosticsTrace("Batch delete", result.RequestCharge, result.Diagnostics);
+            batches.Add(batch);
         }
-        catch (CosmosException cex)
-        {
-            _logger.LogCosmosException(new { enumeratedIds, partitionKeyValue }, cex);
-            throw new CosmosFriendlyException("Batch delete failed. See inner exception for details.", cex);
-        }
+
+        return batches;
     }
 }

--- a/server/Infrastructure/Infrastructure.Cosmos/IRepository.cs
+++ b/server/Infrastructure/Infrastructure.Cosmos/IRepository.cs
@@ -43,7 +43,6 @@ public interface IRepository<TEntity>
 
     // Create
     Task<TEntity?> CreateAsync(TEntity entity,CancellationToken cancellationToken = default);
-    Task CreateAsBatchAsync(IEnumerable<TEntity> entities,CancellationToken cancellationToken = default); // All entities must share the same partition key
 
     // Update
     Task<TEntity?> UpdateAsync(TEntity entity,CancellationToken cancellationToken = default);
@@ -55,6 +54,8 @@ public interface IRepository<TEntity>
     Task<bool> DeleteAsync(TEntity entity, CancellationToken cancellationToken = default);
     Task<bool> DeleteAsync(string id, string partitionKeyValue, CancellationToken cancellationToken = default);
 
+    // Batch operations
+    Task CreateAsBatchAsync(IEnumerable<TEntity> entities,CancellationToken cancellationToken = default);
+    Task UpdateAsBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
     Task DeleteAsBatchAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
-    Task DeleteAsBatchAsync(IEnumerable<string> ids, string partitionKeyValue, CancellationToken cancellationToken = default); // All entities must share the same partition key
 }


### PR DESCRIPTION
- Added grouping to allow for items with any partition key to be batched
- Within each partition key, batches of 100 are used to keep within Cosmos DB batch limits